### PR TITLE
Add constructors for only plugin and file name

### DIFF
--- a/src/main/java/dev/perryplaysmc/dynamicconfigurations/json/DynamicJsonConfiguration.java
+++ b/src/main/java/dev/perryplaysmc/dynamicconfigurations/json/DynamicJsonConfiguration.java
@@ -54,10 +54,14 @@ public class DynamicJsonConfiguration implements IDynamicConfiguration {
     adapter.gson(GSON);
     DynamicConfigurationManager.addConfiguration(this);
   }
-  public DynamicJsonConfiguration(String name) {
-    this(null, (File)null, name);
+
+  public DynamicJsonConfiguration(JavaPlugin plugin, String name) {
+    this(plugin, (File) null, name);
   }
 
+  public DynamicJsonConfiguration(String name) {
+    this(null, (File) null, name);
+  }
 
   public DynamicJsonConfiguration(JavaPlugin plugin, String directory, String name) {
     this(plugin, directory == null || directory.isEmpty() ? null : new File(directory), name);

--- a/src/main/java/dev/perryplaysmc/dynamicconfigurations/yaml/DynamicYamlConfiguration.java
+++ b/src/main/java/dev/perryplaysmc/dynamicconfigurations/yaml/DynamicYamlConfiguration.java
@@ -62,8 +62,12 @@ public class DynamicYamlConfiguration implements IDynamicConfiguration {
     this(plugin, directory == null || directory.isEmpty() ? null : new File(directory), name);
   }
 
+  public DynamicYamlConfiguration(JavaPlugin plugin, String name) {
+    this(plugin, (File) null, name);
+  }
+
   public DynamicYamlConfiguration(String name) {
-    this(null, (File)null, name);
+    this(null, (File) null, name);
   }
 
   public DynamicYamlConfiguration(JavaPlugin plugin, DynamicConfigurationDirectory directory, String name) {


### PR DESCRIPTION
Adds a constructor to the `DynamicJsonConfiguration` and `DynamicYamlConfiguration` that only takes a `JavaPlugin` and a file name.